### PR TITLE
Fix build error around  src/context.ts:42:14 getUser(): user {

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -35,11 +35,11 @@ export class Context implements Clova.ClientContext {
   }
 
   /**
-   * Get user from clova request
+   * Get {Clova.User} from clova request
    *
    * @memberOf Context
    */
-  getUser(): user {
+  getUser(): Clova.User {
     return this.requestObject.session.user;
   }
 


### PR DESCRIPTION
This PR fixes following error.

```
% npm run build

> @line/clova-cek-sdk-nodejs@1.0.1 prebuild /xxx/clova-cek-sdk-nodejs
> rimraf dist

> @line/clova-cek-sdk-nodejs@1.0.1 build /xxx/clova-cek-sdk-nodejs
> tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --target es6 --theme minimal --mode file src

src/context.ts:42:14 - error TS2304: Cannot find name 'user'.

42   getUser(): user {
                ~~~~

src/context.ts:42:14 - error TS4055: Return type of public method from exported class has or is using private name 'user'.

42   getUser(): user {
                ~~~~

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @line/clova-cek-sdk-nodejs@1.0.1 build: `tsc --module commonjs && rollup -c rollup.config.ts && typedoc --out docs --target es6 --theme minimal --mode file src`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the @line/clova-cek-sdk-nodejs@1.0.1 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/JP20217/.npm/_logs/2018-08-26T02_22_07_219Z-debug.log
zsh: exit 1     npm run build
```