### PR TITLE
Modify setOutputSpeech method

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -96,9 +96,8 @@ export class Context implements Clova.ClientContext {
   setOutputSpeech(outputSpeech: Clova.OutputSpeech, reprompt: boolean = false): void {
     if (reprompt) {
       this.responseObject.response.reprompt = { outputSpeech };
-    } else {
-      this.responseObject.response.outputSpeech = outputSpeech;
     }
+    this.responseObject.response.outputSpeech = outputSpeech;
   }
 
   /**

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -96,6 +96,18 @@ describe('Clova Skill Client Context: LaunchRequest', () => {
     });
   });
 
+  it('should set the same phrase to outputSpeech and reprompt using reprompt option', () => {
+    const speechInfo = SpeechBuilder.createSpeechText('こんにちは');
+    const speechObject: Clova.OutputSpeechSimple = {
+      type: 'SimpleSpeech',
+      values: speechInfo,
+    };
+
+    context.setOutputSpeech(speechObject, true);
+    expect(responseObject.response.outputSpeech).toEqual(speechObject);
+    expect(responseObject.response.reprompt.outputSpeech).toEqual(speechObject);
+  });
+
   it('should set shouldEndSession for response object', () => {
     context.endSession();
     expect(responseObject.response.shouldEndSession).toBeTruthy();


### PR DESCRIPTION
I think so too about the following issue and PR.
issu: #10, PR: #14 

And, I think that it will be more convenient if merge this PR.


## For example)

1. set outputSpeech phrase only

```javascript
responseHelper.setSimpleSpeech('Hello!');
```

2. set the same phrase to outputSpeech and reprompt (this PR)

```javascript
responseHelper.setSimpleSpeech('Hello!', true);
```

3. set the different phrase to reprompt (when merged PR: #14 )

```javascript
responseHelper.setSimpleSpeech('Hello!');
responseHelper.setReprompt('May I help you?');
```

## Caution!
if you are already using the reprompt option, there any possibility the behavior will change.
(Perhaps, the reprompt option may be unnecessary.)