### PR TITLE
Fix to store empty object in sessionAttributes if request session is null.

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import Clova from './types';
-import 'core-js/library/fn/object/values';
+import 'core-js/fn/object/values';
 
 /**
  * Create Context for clova response.

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,7 @@ export class Context implements Clova.ClientContext {
         outputSpeech: {},
         shouldEndSession: false,
       },
-      sessionAttributes: (req.session && req.session.sessionAttributes) || {},
+      sessionAttributes: req.session && req.session.sessionAttributes || {},
       version: req.version,
     };
   }

--- a/src/context.ts
+++ b/src/context.ts
@@ -19,7 +19,7 @@ export class Context implements Clova.ClientContext {
         outputSpeech: {},
         shouldEndSession: false,
       },
-      sessionAttributes: req.session.sessionAttributes,
+      sessionAttributes: (req.session && req.session.sessionAttributes) || {},
       version: req.version,
     };
   }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -102,6 +102,12 @@ describe('Clova Skill Client Context: LaunchRequest', () => {
     expect(responseObject.sessionAttributes).toEqual({});
   });
 
+  it('should set sessionAttributes for response object', () => {
+    const sessionAttributes = { intent: 'AddInfo' };
+    context.setSessionAttributes(sessionAttributes);
+    expect(responseObject.sessionAttributes).toEqual(sessionAttributes);
+  });
+
   it('should not get any slots from launch request', () => {
     const slots = context.getSlots();
     expect(slots).toEqual({});
@@ -163,5 +169,10 @@ describe('Clova Skill Client Context: IntentRequest', () => {
   it('should get sessionId from intent request', () => {
     const sessionId = context.getSessionId();
     expect(sessionId).toBe('a29cfead-c5ba-474d-8745-6c1a6625f0c5');
+  });
+
+  it('should get sessionAttributes from intent request', () => {
+    const sessionAttributes = context.getSessionAttributes();
+    expect(sessionAttributes).toEqual({ intent: 'OrderPizza' });
   });
 });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -102,12 +102,6 @@ describe('Clova Skill Client Context: LaunchRequest', () => {
     expect(responseObject.sessionAttributes).toEqual({});
   });
 
-  it('should set sessionAttributes for response object', () => {
-    const sessionAttributes = { intent: 'AddInfo' };
-    context.setSessionAttributes(sessionAttributes);
-    expect(responseObject.sessionAttributes).toEqual(sessionAttributes);
-  });
-
   it('should not get any slots from launch request', () => {
     const slots = context.getSlots();
     expect(slots).toEqual({});
@@ -169,10 +163,5 @@ describe('Clova Skill Client Context: IntentRequest', () => {
   it('should get sessionId from intent request', () => {
     const sessionId = context.getSessionId();
     expect(sessionId).toBe('a29cfead-c5ba-474d-8745-6c1a6625f0c5');
-  });
-
-  it('should get sessionAttributes from intent request', () => {
-    const sessionAttributes = context.getSessionAttributes();
-    expect(sessionAttributes).toEqual({ intent: 'OrderPizza' });
   });
 });


### PR DESCRIPTION
Basically, the value of session is null in EventRequest which occurs when enabling / disabling skill.
However, an attempt is made to embed req.session.sessionAttributes in the sessionAttributes of response in Context constructor and an error occurs.
Fix to include empty object if session is null.