### PR TITLE
Make the default value of shouldEndSession true in the case of receiving EventRequests

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -17,9 +17,9 @@ export class Context implements Clova.ClientContext {
         card: {},
         directives: [],
         outputSpeech: {},
-        shouldEndSession: false,
+        shouldEndSession: req.request.type === 'EventRequest',
       },
-      sessionAttributes: req.session && req.session.sessionAttributes || {},
+      sessionAttributes: (req.session && req.session.sessionAttributes) || {},
       version: req.version,
     };
   }


### PR DESCRIPTION
The EventRequest is issued
- when switching the skill status
- when using AudioPlayer

Since we rarely start conversations from these use cases, I've updated the default value of `shouldEndSession`.