### PR TITLE
fix message, 'has no default export.'

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import * as express from 'express';
 
 declare namespace Clova {
   export interface ClovaMessage {
@@ -68,8 +68,19 @@ declare namespace Clova {
     timestamp: string;
     locale: string;
     extensionId: string;
-    event: clovaSkill.SkillEnabled | clovaSkill.SkillDisabled | audioPlayer.PlayFinished | audioPlayer.PlayPaused | audioPlayer.PlayResumed | audioPlayer.PlayStarted | audioPlayer.PlayStopped | audioPlayer.ProgressReportDelayPassed | audioPlayer.ProgressReportIntervalPassed | audioPlayer.ProgressReportPositionPassed | audioPlayer.StreamRequested;
-  }
+    event:
+      | clovaSkill.SkillEnabled
+      | clovaSkill.SkillDisabled
+      | audioPlayer.PlayFinished
+      | audioPlayer.PlayPaused
+      | audioPlayer.PlayResumed
+      | audioPlayer.PlayStarted
+      | audioPlayer.PlayStopped
+      | audioPlayer.ProgressReportDelayPassed
+      | audioPlayer.ProgressReportIntervalPassed
+      | audioPlayer.ProgressReportPositionPassed
+      | audioPlayer.StreamRequested;
+  };
 
   export type SessionEndedRequest = {
     type: 'SessionEndedRequest';
@@ -216,7 +227,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface PlayPaused {
@@ -225,7 +236,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface PlayResumed {
@@ -234,7 +245,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface PlayStarted {
@@ -243,7 +254,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface PlayStopped {
@@ -252,7 +263,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface ProgressReportDelayPassed {
@@ -261,7 +272,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface ProgressReportIntervalPassed {
@@ -270,7 +281,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface ProgressReportPositionPassed {
@@ -279,7 +290,7 @@ declare namespace Clova {
       payload: {
         offsetInMilliseconds: number;
         token: string;
-      }
+      };
     }
 
     interface StreamRequested {

--- a/src/verifierMiddleware.ts
+++ b/src/verifierMiddleware.ts
@@ -1,5 +1,5 @@
 import { raw } from 'body-parser';
-import express from 'express';
+import * as express from 'express';
 import Clova from './types';
 import verifier from './verifier';
 


### PR DESCRIPTION
when develop to use typescript, 
show error of `Module '"..."' has no default export.` 
so I fixed it.

following comment in express source code.

```
/* =================== USAGE ===================

    import * as express from "express";
    var app = express();

 =============================================== */
```